### PR TITLE
Featured Image Sizes Patch

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -24,7 +24,8 @@ if ( file_exists( $child_block_extensions ) ) {
  */
 function setup() {
     // Add custom image size for index page.
-    add_image_size('featured-vertical', 350, 525, true);
+    add_image_size('featured-large', 485, 725, true);
+    add_image_size('featured-vertical', 388, 525, true);
 }
 add_action( 'after_setup_theme', 'setup' );
 
@@ -33,6 +34,10 @@ add_action( 'after_setup_theme', 'setup' );
  */
 function add_image_size_to_blocks() {
     add_filter('block_editor_settings_all', function($settings) {
+        $settings['imageSizes'][] = [
+            'slug' => 'featured-large',
+            'name' => __('Featured Large', 'moiraine')
+        ];
         $settings['imageSizes'][] = [
             'slug' => 'featured-vertical',
             'name' => __('Featured Vertical', 'moiraine')

--- a/functions.php
+++ b/functions.php
@@ -25,13 +25,6 @@ if ( file_exists( $child_block_extensions ) ) {
 function setup() {
     // Add custom image size for index page.
     add_image_size('featured-vertical', 350, 525, true);
-
-    // Add the size to WordPress size dropdown
-    add_filter('image_size_names_choose', function($sizes) {
-        return array_merge($sizes, [
-            'featured-vertical' => __('Featured Vertical', 'moiraine')
-        ]);
-    });
 }
 add_action( 'after_setup_theme', 'setup' );
 

--- a/style.css
+++ b/style.css
@@ -5,22 +5,9 @@ Description:  A child theme for Moiraine.
 Author:       Imagewize
 Author URI:   https://imagewize.com
 Template:     moiraine
-Version:      1.1.0
+Version:      1.0.0
 License:      GNU General Public License v2 or later
 License URI:  http://www.gnu.org/licenses/gpl-2.0.html
 Tags:         Tags: blog, portfolio, entertainment
 Text Domain:  thaiconomics
 */
-
-.featured-post-query .wp-block-post-featured-image img {
-    max-width: 350px !important;
-    height: 525px !important;
-    object-fit: cover;
-}
-
-/* Fix for home top query loop post featured images */
-.wp-block-query .wp-block-post-featured-image img {
-    width: 388px !important;
-    height: 525px !important;
-    object-fit: cover;
-}

--- a/style.css
+++ b/style.css
@@ -17,3 +17,10 @@ Text Domain:  thaiconomics
     height: 525px !important;
     object-fit: cover;
 }
+
+/* Fix for home top query loop post featured images */
+.wp-block-query .wp-block-post-featured-image img {
+    width: 388px !important;
+    height: 525px !important;
+    object-fit: cover;
+}


### PR DESCRIPTION
This pull request introduces updates to image sizes and their integration into the WordPress editor, along with a minor correction to the theme version and the removal of outdated CSS. Below are the key changes:

### Updates to image sizes:
* [`functions.php`](diffhunk://#diff-01c9525afc2c87cfcb03124117c9d0ebb067029f6c955a607fa0fd4274aca556L27-R28): Replaced the `featured-vertical` image size with updated dimensions (388x525) and added a new `featured-large` image size (485x725). These sizes are also registered for use in the WordPress block editor. [[1]](diffhunk://#diff-01c9525afc2c87cfcb03124117c9d0ebb067029f6c955a607fa0fd4274aca556L27-R28) [[2]](diffhunk://#diff-01c9525afc2c87cfcb03124117c9d0ebb067029f6c955a607fa0fd4274aca556R37-R40)

### Theme metadata and styling cleanup:
* [`style.css`](diffhunk://#diff-b78be019f1dc6d57753ea900c3805b114cd53ab7c0db836cc081836df1b99b7aL8-L19): Corrected the theme version from `1.1.0` to `1.0.0` and removed redundant CSS rules related to `.featured-post-query` images to align with the updated image size logic.